### PR TITLE
Support "&lt;3" similar as "<3", for escaped string in "shorts"

### DIFF
--- a/src/smilies/config.json
+++ b/src/smilies/config.json
@@ -10,6 +10,7 @@
     ";-(": "cry",
     "OO": "eek",
     "<3": "like",
+    "&lt;3": "like",
     "^^": "lol",
     ":|": "neutral",
     ":-|": "neutral",


### PR DESCRIPTION
Adding support for HTML escaped "<" (lower than) character 

Enable "like" smiley when dealing with html escaped string
